### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BaiduGoingRefreshLayout
 
-#说明：
+# 说明：
 之前并没注意，太阳和轮子的旋转并不匀速，博客上有人提出来了，看了一下，在xml里面设置插值器并不起作用，大家可以参考：
 http://blog.csdn.net/jiangwei0910410003/article/details/16985999
 四哥的博客，代码已经更新


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
